### PR TITLE
PAL-119 Connecting appointments page to the database

### DIFF
--- a/lib/components/appointment_card.dart
+++ b/lib/components/appointment_card.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 import 'package:intl/date_symbol_data_local.dart';
+import 'package:pallinet/firestore/firestore.dart';
 
 class AppointmentCard extends StatelessWidget {
   const AppointmentCard({
@@ -17,7 +18,7 @@ class AppointmentCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-        onTap: () => {debugPrint('$name tapped')},
+        onTap: () => {retrieveAppointmentsPhysicians()},
         child: Card(
             child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 5.0),

--- a/lib/components/appointment_card.dart
+++ b/lib/components/appointment_card.dart
@@ -7,12 +7,10 @@ class AppointmentCard extends StatelessWidget {
   const AppointmentCard({
     super.key,
     required this.name,
-    required this.time,
     required this.date,
   });
 
   final String name;
-  final String time;
   final DateTime date;
 
   @override
@@ -32,7 +30,7 @@ class AppointmentCard extends StatelessWidget {
               Expanded(
                 flex: 4,
                 child:
-                    _AppointmentDescription(name: name, time: time, date: date),
+                    _AppointmentDescription(name: name, date: date),
               ),
               const Icon(
                 Icons.more_vert,
@@ -47,12 +45,10 @@ class AppointmentCard extends StatelessWidget {
 class _AppointmentDescription extends StatelessWidget {
   const _AppointmentDescription({
     required this.name,
-    required this.time,
     required this.date,
   });
 
   final String name;
-  final String time;
   final DateTime date;
 
   @override
@@ -77,7 +73,7 @@ class _AppointmentDescription extends StatelessWidget {
           ),
           const Padding(padding: EdgeInsets.symmetric(vertical: 1.0)),
           Text(
-            'Time: $time',
+            'Time: ${DateFormat('hh:mm').format(date)}',
             style: const TextStyle(fontSize: 14.0),
           ),
           Text(

--- a/lib/components/appointment_card.dart
+++ b/lib/components/appointment_card.dart
@@ -16,7 +16,7 @@ class AppointmentCard extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return InkWell(
-        onTap: () => {retrieveAppointmentsPhysicians()},
+        onTap: () => {debugPrint("xd")},
         child: Card(
             child: Padding(
           padding: const EdgeInsets.symmetric(vertical: 5.0),

--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -340,6 +340,7 @@ void updatePatientDetails(Map<dynamic, dynamic> data, id) async {
 
 //retreives the appointments specific to the physician using their id
 //first accesses the entire appointments collection and then seperates out the ones specific to them
+//currently hardcoded as I figure out how to pass the physician id into the appointments page
 Future<List<dynamic>>? retrieveAppointmentsPhysicians() async {
 
   QuerySnapshot appointments = await db

--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -337,6 +337,18 @@ void updatePatientDetails(Map<dynamic, dynamic> data, id) async {
   // patientRef.update({"gender": data["gender"]});
 }
 
-FirebaseFirestore getDatabase() {
-  return db;
+
+//retreives the appointments specific to the physician using their id
+//first accesses the entire appointments collection and then seperates out the ones specific to them
+Future<List<dynamic>>? retrieveAppointmentsPhysicians() async {
+
+  QuerySnapshot appointments = await db
+    .collection("Appointment")
+    .where('practitioner', isEqualTo: '2222222')
+    .get();
+  final allData = appointments.docs.map((doc) => doc.data()).toList();
+  debugPrint(allData.toString());
+  return allData;
+
 }
+

--- a/lib/firestore/firestore.dart
+++ b/lib/firestore/firestore.dart
@@ -341,15 +341,42 @@ void updatePatientDetails(Map<dynamic, dynamic> data, id) async {
 //retreives the appointments specific to the physician using their id
 //first accesses the entire appointments collection and then seperates out the ones specific to them
 //currently hardcoded as I figure out how to pass the physician id into the appointments page
-Future<List<dynamic>>? retrieveAppointmentsPhysicians() async {
+Future<List<dynamic>> retrieveAppointmentsPhysicians(uid) async {
+  debugPrint(uid);
+  Map<dynamic, dynamic> physician = await db
+      .collection("Practitioner")
+      .doc(uid)
+      .get()
+      .then((DocumentSnapshot doc) {
+    return doc.data() as Map<String, dynamic>;
+  }, onError: (e) => debugPrint("Error getting document: $e"));
 
+ 
   QuerySnapshot appointments = await db
     .collection("Appointment")
-    .where('practitioner', isEqualTo: '2222222')
+    .where('practitioner', isEqualTo: physician["id"])
     .get();
   final allData = appointments.docs.map((doc) => doc.data()).toList();
   debugPrint(allData.toString());
   return allData;
-
 }
 
+Future<List<dynamic>> retrieveAppointmentsPatients(uid) async {
+  debugPrint(uid);
+  Map<dynamic, dynamic> patient = await db
+      .collection("Patient")
+      .doc(uid)
+      .get()
+      .then((DocumentSnapshot doc) {
+    return doc.data() as Map<String, dynamic>;
+  }, onError: (e) => debugPrint("Error getting document: $e"));
+
+ debugPrint(patient.toString());
+  QuerySnapshot appointments = await db
+    .collection("Appointment")
+    .where('patient', isEqualTo: patient["name"]["text"])
+    .get();
+  final allData = appointments.docs.map((doc) => doc.data()).toList();
+  debugPrint(allData.toString());
+  return allData;
+}

--- a/lib/views/patient/patient_appointments.dart
+++ b/lib/views/patient/patient_appointments.dart
@@ -19,7 +19,6 @@ class PatientAppointments extends StatelessWidget {
           AppointmentCard(
             name: "Dr. Totally Real Doctor",
             date: DateTime(2023, 2,  21),
-            time: "12:30PM"
             ),
           const Padding(padding: EdgeInsets.all(16.0)),
           const Text(
@@ -29,7 +28,6 @@ class PatientAppointments extends StatelessWidget {
           AppointmentCard(
             name: "Dr. Lanyard",
             date: DateTime(2022, 12,  25),
-            time: "1:30PM"
           ),
           const Padding(padding: EdgeInsets.all(16.0)),
           ElevatedButton(

--- a/lib/views/patient/patient_appointments.dart
+++ b/lib/views/patient/patient_appointments.dart
@@ -1,58 +1,61 @@
 import 'package:flutter/material.dart';
 import 'package:pallinet/components/appointment_card.dart';
+import 'package:pallinet/models/session_manager.dart';
+import 'package:pallinet/firestore/firestore.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
 
-class PatientAppointments extends StatelessWidget {
+class PatientAppointments extends StatefulWidget {
   const PatientAppointments({super.key});
+
+  @override
+  State<PatientAppointments> createState() => _PatientAppointmentsState();
+}
+
+class _PatientAppointmentsState extends State<PatientAppointments> {
+  late final SessionManager _prefs;
+
+  @override
+  void initState() {
+    _prefs = SessionManager();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
 @override
   Widget build(BuildContext context) {
-    // double screenWidth = MediaQuery.of(context).size.width;
-    return Scaffold(
-      appBar: AppBar(title: const Text("Appointments")),
-      body: 
-      ListView(
-        padding: const EdgeInsets.all(8),
-        children: [
-          const Text(
-            "Upcoming Appointments", 
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
-          ),
-          AppointmentCard(
-            name: "Dr. Totally Real Doctor",
-            date: DateTime(2023, 2,  21),
+    return Column(
+      children: [
+        Expanded(child: FutureBuilder<List<dynamic>>(
+        future: _prefs.getUid().then((uid) => retrieveAppointmentsPatients(uid)),
+        builder: ((context, snapshot) {
+          final list = snapshot.data == null
+              ? []
+              : (snapshot.data as List)
+                  .map((e) => e as Map<String, dynamic>)
+                  .toList();
+          return Scaffold(
+            appBar: AppBar(title: const Text("Appointments")),
+            body: ListView.builder(
+              itemCount: list.length,
+              itemBuilder: (BuildContext context, int index) {
+                final data = list[index];
+                Timestamp t = data["scheduledTimeStart"] as Timestamp;
+                DateTime startTime = t.toDate();
+                return AppointmentCard(
+                  name: data["appointmentType"],
+                  date: startTime,
+                );
+              },
             ),
-          const Padding(padding: EdgeInsets.all(16.0)),
-          const Text(
-            "Past Appointments", 
-          style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
-          ),
-          AppointmentCard(
-            name: "Dr. Lanyard",
-            date: DateTime(2022, 12,  25),
-          ),
-          const Padding(padding: EdgeInsets.all(16.0)),
-          ElevatedButton(
-              onPressed: () => {debugPrint('schedule tapped')},
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.white, // Background color
-              ),
-              child: Row(
-                children: const [
-                  Icon(
-                    Icons.schedule,
-                    color: Colors.pink,
-                    size: 40,
-                  ),
-                  SizedBox(
-                    width: 20,
-                  ),
-                  Text(
-                    'Schedule Appointment',
-                    style: TextStyle(fontSize: 15, color: Colors.black),
-                  )
-                ],
-              )),
-        ],
+          );
+         }),
+        ),
       ),
+      ]
     );
   }
 }

--- a/lib/views/physician/patients_list.dart
+++ b/lib/views/physician/patients_list.dart
@@ -3,11 +3,32 @@ import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:pallinet/components/patient_card.dart';
 import 'package:pallinet/firestore/firestore.dart';
+import 'package:pallinet/models/session_manager.dart';
 
-class PatientList extends StatelessWidget {
+class PatientList extends StatefulWidget {
   const PatientList({super.key});
 
+  @override
+  State<PatientList> createState() => _PatientListState();
+}
+
+class _PatientListState extends State<PatientList> {
   // final test = retrievePatients();
+  late final SessionManager _prefs;
+
+  @override
+  void initState() {
+    _prefs = SessionManager();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+  
+  //TODO create retrieve id method in firestore to get physician ID and then put into retrievePatients()
+
 
   @override
   Widget build(BuildContext context) {

--- a/lib/views/physician/physician_appointments.dart
+++ b/lib/views/physician/physician_appointments.dart
@@ -1,52 +1,85 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
 import 'package:pallinet/components/appointment_card.dart';
-
+import 'package:pallinet/firestore/firestore.dart';
+import 'package:pallinet/models/session_manager.dart';
 class PhysicianAppointments extends StatelessWidget {
   const PhysicianAppointments({super.key});
-
+  
   @override
   Widget build(BuildContext context) {
-    // double screenWidth = MediaQuery.of(context).size.width;
-    return Scaffold(
-      appBar: AppBar(title: const Text("Appointments")),
-      body: ListView(
-        padding: const EdgeInsets.all(8),
-        children: [
-          const Text(
-            "Upcoming Appointments",
-            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+    return FutureBuilder<List<dynamic>>(
+      future: retrieveAppointmentsPhysicians(),
+      builder: ((context, snapshot) {
+        final list = snapshot.data == null
+            ? []
+            : (snapshot.data as List)
+                .map((e) => e as Map<String, dynamic>)
+                .toList();
+        return Scaffold(
+          appBar: AppBar(title: const Text("Patients")),
+          body: ListView.builder(
+            itemCount: list.length,
+            itemBuilder: (BuildContext context, int index) {
+              final data = list[index];
+              Timestamp t = data["scheduledTimeStart"] as Timestamp;
+              DateTime startTime = t.toDate();
+              return AppointmentCard(
+                name: data["patient"],
+                date: startTime,
+                time: "1:30"
+              );
+            },
           ),
-          AppointmentCard(name: "Kenny Hoang", date: DateTime(2023, 2, 21), time: "12:30PM"),
-          const Padding(padding: EdgeInsets.all(16.0)),
-          const Text(
-            "Past Appointments",
-            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
-          ),
-          AppointmentCard(name: "Jenny Ang", date: DateTime(2022, 12, 25), time: "1:30PM"),
-          const Padding(padding: EdgeInsets.all(16.0)),
-          ElevatedButton(
-              onPressed: () => {Navigator.pushNamed(context, "/physician/appointments/new")},
-              style: ElevatedButton.styleFrom(
-                backgroundColor: Colors.white, // Background color
-              ),
-              child: Row(
-                children: const [
-                  Icon(
-                    Icons.schedule,
-                    color: Colors.pink,
-                    size: 40,
-                  ),
-                  SizedBox(
-                    width: 20,
-                  ),
-                  Text(
-                    'Schedule Appointment',
-                    style: TextStyle(fontSize: 15, color: Colors.black),
-                  )
-                ],
-              )),
-        ],
-      ),
+        );
+      }),
     );
   }
 }
+
+//   @override
+//   Widget build(BuildContext context) {
+//     // double screenWidth = MediaQuery.of(context).size.width;
+//     return Scaffold(
+//       appBar: AppBar(title: const Text("Appointments")),
+//       body: ListView(
+//         padding: const EdgeInsets.all(8),
+//         children: [
+//           const Text(
+//             "Upcoming Appointments",
+//             style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+//           ),
+//           AppointmentCard(name: "Kenny Hoang", date: DateTime(2023, 2, 21), time: "12:30PM"),
+//           const Padding(padding: EdgeInsets.all(16.0)),
+//           const Text(
+//             "Past Appointments",
+//             style: TextStyle(fontWeight: FontWeight.bold, fontSize: 20),
+//           ),
+//           AppointmentCard(name: "Jenny Ang", date: DateTime(2022, 12, 25), time: "1:30PM"),
+//           const Padding(padding: EdgeInsets.all(16.0)),
+//           ElevatedButton(
+//               onPressed: () => {Navigator.pushNamed(context, "/physician/appointments/new")},
+//               style: ElevatedButton.styleFrom(
+//                 backgroundColor: Colors.white, // Background color
+//               ),
+//               child: Row(
+//                 children: const [
+//                   Icon(
+//                     Icons.schedule,
+//                     color: Colors.pink,
+//                     size: 40,
+//                   ),
+//                   SizedBox(
+//                     width: 20,
+//                   ),
+//                   Text(
+//                     'Schedule Appointment',
+//                     style: TextStyle(fontSize: 15, color: Colors.black),
+//                   )
+//                 ],
+//               )),
+//         ],
+//       ),
+//     );
+//   }
+// }

--- a/lib/views/physician/physician_appointments.dart
+++ b/lib/views/physician/physician_appointments.dart
@@ -27,7 +27,6 @@ class PhysicianAppointments extends StatelessWidget {
               return AppointmentCard(
                 name: data["patient"],
                 date: startTime,
-                time: "1:30"
               );
             },
           ),

--- a/lib/views/physician/physician_appointments.dart
+++ b/lib/views/physician/physician_appointments.dart
@@ -3,35 +3,58 @@ import 'package:flutter/material.dart';
 import 'package:pallinet/components/appointment_card.dart';
 import 'package:pallinet/firestore/firestore.dart';
 import 'package:pallinet/models/session_manager.dart';
-class PhysicianAppointments extends StatelessWidget {
+class PhysicianAppointments extends StatefulWidget {
   const PhysicianAppointments({super.key});
-  
+
+  @override
+  State<PhysicianAppointments> createState() => _PhysicianAppointmentsState();
+}
+
+class _PhysicianAppointmentsState extends State<PhysicianAppointments> {
+  late final SessionManager _prefs;
+
+  @override
+  void initState() {
+    _prefs = SessionManager();
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<dynamic>>(
-      future: retrieveAppointmentsPhysicians(),
-      builder: ((context, snapshot) {
-        final list = snapshot.data == null
-            ? []
-            : (snapshot.data as List)
-                .map((e) => e as Map<String, dynamic>)
-                .toList();
-        return Scaffold(
-          appBar: AppBar(title: const Text("Patients")),
-          body: ListView.builder(
-            itemCount: list.length,
-            itemBuilder: (BuildContext context, int index) {
-              final data = list[index];
-              Timestamp t = data["scheduledTimeStart"] as Timestamp;
-              DateTime startTime = t.toDate();
-              return AppointmentCard(
-                name: data["patient"],
-                date: startTime,
-              );
-            },
-          ),
-        );
-      }),
+    return Column(
+      children: [
+        Expanded(child: FutureBuilder<List<dynamic>>(
+        future: _prefs.getUid().then((uid) => retrieveAppointmentsPhysicians(uid)),
+        builder: ((context, snapshot) {
+          final list = snapshot.data == null
+              ? []
+              : (snapshot.data as List)
+                  .map((e) => e as Map<String, dynamic>)
+                  .toList();
+          return Scaffold(
+            appBar: AppBar(title: const Text("Appointments")),
+            body: ListView.builder(
+              itemCount: list.length,
+              itemBuilder: (BuildContext context, int index) {
+                final data = list[index];
+                Timestamp t = data["scheduledTimeStart"] as Timestamp;
+                DateTime startTime = t.toDate();
+                return AppointmentCard(
+                  name: data["patient"],
+                  date: startTime,
+                );
+              },
+            ),
+          );
+         }),
+        ),
+      ),
+      ]
     );
   }
 }


### PR DESCRIPTION
## Relevant Issue
[PAL-119](https://pallinet.atlassian.net/browse/PAL-119?atlOrigin=eyJpIjoiOTA1MmI3ZjVmOTJiNDQ2YjkwZDM1NWMzYjlhMjIyZGYiLCJwIjoiaiJ9)

## Description
Connected the appointments list page to the database so the user accessing the app can see what appointment are upcoming.
Currently it checks between the appointment documents and the user's information. If the user is a patient, it checks the patient field in the appointments documents and compares the name. If the name is the same, then it adds it to the future builder. Same thing on the physician side where it checks the practitioner id field with the user's id field from the database.

Possible suggestions and changes to be made:
Currently with this set up, we would have an error as referencing purely the name would cause people with the same names to have matching appointments which should not be the case.
Altering the patient name to match instead with the uid or some other patient identifier would be more ideal. (potentially add in an ID identifier like the physicians but instead have it be a randomly generated number perhaps?
