### PR TITLE
Add navigation to contacts page

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,6 +30,7 @@ import 'package:pallinet/views/forget_password.dart';
 import 'package:pallinet/views/forgot_password_success.dart';
 import 'package:pallinet/views/patient/patient_end_of_life_plans.dart';
 import 'package:pallinet/views/detailed_appointment_view.dart';
+import 'package:pallinet/views/contacts_page.dart';
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -82,6 +83,7 @@ class PalliNet extends StatelessWidget {
           '/physician/profile': (context) => const ProfileContent(),
           '/forgotsuccess': (context) => const ForgotSuccess(),
           '/chart': (context) => const Chart(),
+          '/contacts': (context) => const ContactsPage()
         },
         onUnknownRoute: (settings) =>
             MaterialPageRoute(builder: (context) => const HomePage()));

--- a/lib/views/chat_page.dart
+++ b/lib/views/chat_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ChatPage extends StatelessWidget {
+  const ChatPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
+    return Scaffold(
+        body: Center(
+      child: Column(
+        children: [
+          Text("ChatPage"),
+        ],
+      ),
+    ));
+  }
+}

--- a/lib/views/contacts_page.dart
+++ b/lib/views/contacts_page.dart
@@ -1,0 +1,18 @@
+import 'package:flutter/material.dart';
+
+class ContactsPage extends StatelessWidget {
+  const ContactsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    double screenWidth = MediaQuery.of(context).size.width;
+    return Scaffold(
+        body: Center(
+      child: Column(
+        children: [
+          Text("contacts_page"),
+        ],
+      ),
+    ));
+  }
+}

--- a/lib/views/physician/physician_home.dart
+++ b/lib/views/physician/physician_home.dart
@@ -60,6 +60,13 @@ class _PhysicianHomeState extends State<PhysicianHome> {
                   ),
                   gap(),
                   const CustomButton(
+                    icon: Icons.people,
+                    iconColor: Colors.pink,
+                    route: '/contacts',
+                    text: 'Messages',
+                  ),
+                  gap(),
+                  const CustomButton(
                     icon: Icons.settings,
                     iconColor: Colors.pink,
                     route: '/physician/profile',


### PR DESCRIPTION
## Relevant Issue
[PAL-37] https://pallinet.atlassian.net/browse/PAL-37?atlOrigin=eyJpIjoiNmZjYTgyZDQ5YTk5NDIyZThlZTdiNzUwZGE5ZTE4YjIiLCJwIjoiaiJ9

## Description
Only added in the navigation to the contacts page before moving into the messaging system.
The plan is to have all the contacts present and showing the last message sent in the chat.
