### PR TITLE
Implement a unique ID when creating Patient

### DIFF
--- a/lib/firestore/auth.dart
+++ b/lib/firestore/auth.dart
@@ -1,3 +1,6 @@
+
+import 'dart:math';
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:pallinet/constants.dart';
@@ -9,7 +12,8 @@ SessionManager prefs = SessionManager();
 
 Future<bool> createPatient(payload) async {
   List<String> birthdate = payload["birthdate"].split("/");
-
+  //maximum number the ID can reach. Can be changed if all the IDs are occupied 
+  const int maxID = 9000000;
   try {
     final credential =
         await FirebaseAuth.instance.createUserWithEmailAndPassword(
@@ -17,7 +21,30 @@ Future<bool> createPatient(payload) async {
       password: payload['password'],
     );
     String uid = credential.user!.uid;
-
+    bool check = true;
+    String id = "";
+    Random rand = Random();
+    int loopError = 0;
+    //continually loops until it creates a unique ID for the patient
+    while(check && loopError < maxID + 1000000) {
+      int randID = rand.nextInt(maxID) + 1000000;
+      //Query database for IDs matching the randomly generated one.
+      QuerySnapshot result = (await db.collection("Patient")
+        .where('id', isEqualTo: randID.toString()).get());
+      List<QueryDocumentSnapshot<Object?>> newResult = result.docs;
+      int count = newResult.length;
+      if (count == 0) {
+        id = randID.toString();
+        break;
+      }
+      //If it loops for too long, then we've either created the max number of possible patients with
+      //this length of ID or there was just an error and we must break out of it
+      loopError++;
+    }
+    if (loopError >= maxID + 1000000) {
+      debugPrint("Error assigning ID. Maximum number of patients reached");
+      return false;
+    }
     // Create patient
     db.collection("Patient").doc(uid).set({
       "active": true,
@@ -25,7 +52,7 @@ Future<bool> createPatient(payload) async {
           int.parse(birthdate[1])),
       "deceasedBoolean": false,
       "gender": payload["gender"].value,
-      "id": "1111111", //TODO How are we doing ids?
+      "id": id, 
       "name": {
         "family": payload["lastName"],
         "given": payload["firstName"],

--- a/lib/firestore/auth.dart
+++ b/lib/firestore/auth.dart
@@ -22,10 +22,9 @@ Future<bool> createPatient(payload) async {
     String uid = credential.user!.uid;
     bool check = true;
     String id = "";
-    QuerySnapshot result = await db.collection("Patient").get();
-    List<QueryDocumentSnapshot<Object?>> newResult = result.docs;
+    AggregateQuerySnapshot result = await db.collection("Patient").count().get();
     //Indicing from 1
-    id = (newResult.length + 1).toString().padLeft(lengthID, '0');
+    id = (result.count + 1).toString().padLeft(lengthID, '0');
     
 
     // Create patient


### PR DESCRIPTION
## Relevant Issue
IDs were only 1111111 for all patients

## Description
Implemented a change in auth.dart that randomly generated a number between 1000000 - 9999999. A while loop then checks if this is unique within the database and if it is, breaks and assigns it to the patient. otherwise it will randomly generate again until it is stopped by a checker or is unique.
